### PR TITLE
Add Home path to upload page

### DIFF
--- a/src/main/java/uk/gov/companieshouse/payments/admin/web/controller/refunds/UploadBulkRefundController.java
+++ b/src/main/java/uk/gov/companieshouse/payments/admin/web/controller/refunds/UploadBulkRefundController.java
@@ -20,7 +20,7 @@ import javax.validation.Valid;
 
 @Controller
 @NextController(RefundsSummaryController.class)
-@RequestMapping("/admin/payments/refunds")
+@RequestMapping({"/admin/payments/refunds", "/"})
 public class UploadBulkRefundController extends BaseController {
 
     private static final String UPLOAD_BULK_REFUND = "refunds/uploadBulkRefund";


### PR DESCRIPTION
The `referer` header is being truncated by `strict-origin-when-cross-origin` when the user signs out.
Adding the extra path here returns the user to the start page.

BI-10726