### PR TITLE
use latest dependency-check setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>uk.gov.companieshouse</groupId>
 		<artifactId>companies-house-parent</artifactId>
-		<version>2.1.6</version>
+		<version>2.1.11</version>
 		<relativePath/>
 	</parent>
 


### PR DESCRIPTION
12da3d3 Repoint Makefile at dep-check-suppressions/main
The 'dependency-check' target uses a variable
  dependency_check_suppressions_repo_branch
 which previously pointed to a different branch:
  feature/suppressions-for-company-accounts-api
 ... but that branch has been merged into main and so this variable
 should now point to main.
Tidy Makefile for dependency-check consistency
Remove extraneous comments.
Make line spacing, ordering, format for dependency-check sections
 identical across Makefiles.
Add json to dependency check report formats.

263476b Update parent pom to 2.1.11
2.1.11 brings in latest correct dependency-check settings.

Fixes [CC-1712](https://companieshouse.atlassian.net/browse/CC-1712)